### PR TITLE
Upgrade frontend docker image

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-bullseye
+FROM node:16-bullseye
 
 
 RUN set -ex; \


### PR DESCRIPTION
Increased the frontend nodejs version to 16 as the previous version 14 gave me this error:

```
npm ERR! code EBADPLATFORM
npm ERR! notsup Unsupported platform for esbuild-linux-32@0.13.15: wanted {"os":"linux","arch":"ia32"} (current: {"os":"linux","arch":"x64"})
npm ERR! notsup Valid OS:    linux
npm ERR! notsup Valid Arch:  ia32
npm ERR! notsup Actual OS:   linux
npm ERR! notsup Actual Arch: x64
```