### PR TITLE
Use the docker-compose healthcheck for mssql and explicit depend on the healthcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: init info up down down-hard restart logs logs-all mysql-wait mssql mssql-cli mssql-create-database-dev mssql-create-database-test mssql-show-databases mssql-show-tables flask-setup-views flask-db-upgrade flask-routes load-fixtures flask test test-verbose
 
-init: up mssql-wait mssql-create-database-dev mssql-create-database-test flask-db-upgrade flask-setup-views load-fixtures info
+init: up mssql-create-database-dev mssql-create-database-test flask-db-upgrade flask-setup-views load-fixtures info
 
 
 info:
@@ -37,9 +37,6 @@ logs:
 
 logs-all:
 	docker-compose logs -f
-
-mssql-wait:
-	@while ! docker-compose exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P Passw0rd -Q "select 1;" > /dev/null 2>&1; do sleep 1; done; sleep 2;
 
 mssql:
 	docker-compose exec mssql /bin/bash

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ pytest
 
 ## Running in docker
 
+### Dependencies for docker
+
+- minimum docker version 17.06.0+
+- minimum docker-compose version 1.27.0
+
 To initialise the project you can run:
 ```bash
 make init

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.3'
 
 services:
   api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.8'
 
 services:
   api:
@@ -22,7 +22,8 @@ services:
       TEST_DB_NAME: db_test
       JWT_SECRET: secret
     depends_on:
-      - mssql
+      mssql:
+        condition: service_healthy
     restart: "no"
 
   frontend:
@@ -55,6 +56,12 @@ services:
     volumes:
       - mssql:/var/opt/mssql
       - ./docker/mssql/:/opt/sql/:ro
+    healthcheck:
+      test: /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P Passw0rd -Q "SELECT 1" -b -o /dev/null
+      interval: 1s
+      timeout: 3s
+      retries: 10
+      start_period: 1s
     restart: "no"
 
   nginx:


### PR DESCRIPTION
I moved the `mssql-wait` towards the docker-compose healthcheck system.
And additionally made the docker Api container depend on the healthcheck of mssql.

This again works on my Linux x64 machine.

Would you please check if this also work on Windows and/or Mac (which ever you are using)