### PR TITLE
Bugfix 10222 be able to hide vigerend with new vigerend in the past AB#10222

### DIFF
--- a/Api/Endpoints/data_manager.py
+++ b/Api/Endpoints/data_manager.py
@@ -138,10 +138,8 @@ class DataManager:
                         WHERE
                             {status_condition}
                             UUID != '00000000-0000-0000-0000-000000000000'
-                            
                             /* If it is something from the future then we ignore it in this counter */
                             AND Begin_Geldigheid <= GETDATE()
-                        AND Eind_Geldigheid > GETDATE()
                     )
 
                     SELECT
@@ -149,7 +147,8 @@ class DataManager:
                     FROM
                         {self.valid_view}_inner
                     WHERE
-                        RowNumber = 1
+                            RowNumber = 1
+                        AND Eind_Geldigheid > GETDATE()
                     """
 
         self._run_query_commit(query)

--- a/Api/Endpoints/data_manager.py
+++ b/Api/Endpoints/data_manager.py
@@ -138,8 +138,10 @@ class DataManager:
                         WHERE
                             {status_condition}
                             UUID != '00000000-0000-0000-0000-000000000000'
+                            
+                            /* If it is something from the future then we ignore it in this counter */
+                            AND Begin_Geldigheid <= GETDATE()
                         AND Eind_Geldigheid > GETDATE()
-                        AND Begin_Geldigheid <= GETDATE()
                     )
 
                     SELECT

--- a/Tests/TestUtils/data_loader.py
+++ b/Tests/TestUtils/data_loader.py
@@ -116,6 +116,10 @@ class FixtureLoader():
         self._beleidskeuze("keu:23", ID=1011, UUID="FEC2E000-0011-0026-0000-000000000000", Created_By="geb:admin", Created_Date="2020-01-01T10:00:00", Modified_Date="2020-02-06T10:00:00", Modified_By="geb:admin", Status="Vastgesteld",                   Titel="Versie 2 Vastgesteld - datum is tegenwoordig",                   Afweging="beleidskeuze1011", Begin_Geldigheid="2120-01-01T10:00:00", Eind_Geldigheid="9999-01-01T10:00:00")
         self._beleidskeuze("keu:24", ID=1011, UUID="FEC2E000-0011-0027-0000-000000000000", Created_By="geb:admin", Created_Date="2020-01-01T10:00:00", Modified_Date="2020-02-07T10:00:00", Modified_By="geb:admin", Status="Vigerend",                      Titel="Versie 2 Vigerend - datum is tegenwoordig",                      Afweging="beleidskeuze1011", Begin_Geldigheid="2120-01-01T10:00:00", Eind_Geldigheid="9999-01-01T10:00:00")
 
+        # Beleidskeuze which gets "removed" because a new version is set to the past
+        self._beleidskeuze("keu:30", ID=1030, UUID="FEC2E000-1030-0001-0000-000000000000", Created_By="geb:admin", Created_Date="2020-02-01T10:00:00", Modified_Date="2020-02-01T10:00:00", Modified_By="geb:admin", Status="Vigerend",            Titel="Versie 1 Vigerend en in de huidige tijd", Afweging="beleidskeuze1030", Begin_Geldigheid="2020-01-01T10:00:00", Eind_Geldigheid="2120-01-01T10:00:00")
+        self._beleidskeuze("keu:31", ID=1030, UUID="FEC2E000-1030-0002-0000-000000000000", Created_By="geb:admin", Created_Date="2020-02-01T10:00:00", Modified_Date="2020-03-01T10:00:00", Modified_By="geb:admin", Status="Vigerend",            Titel="Versie 2 Vigerend maar in het verleden",  Afweging="beleidskeuze1030", Begin_Geldigheid="2020-01-01T10:00:00", Eind_Geldigheid="2021-01-01T10:00:00")
+
         # 
         self._ambitie("amb:2", Created_By="geb:admin")
         self._ambitie("amb:3", Created_By="geb:alex", Modified_By="geb:alex")

--- a/Tests/test_api.py
+++ b/Tests/test_api.py
@@ -26,6 +26,14 @@ from Api.Models.beleidsprestaties import Beleidsprestaties
 @pytest.mark.usefixtures("fixture_data")
 class TestApi:
 
+    def test_beleidskeuze_valid_view_past_vigerend(self, client_admin):
+        response = client_admin.get("v0.1/valid/beleidskeuzes?all_filters=Afweging:beleidskeuze1030")
+        assert response.status_code == 200, f"Status code was {response.status_code}"
+        data = response.get_json()
+
+        assert len(data) == 0, f"We are expecting nothing as the most recent Vigerend has its Eind_Geldigheid in the past"
+
+
     def test_beleidskeuze_valid_view_future_vigerend(self, client_admin):
         response = client_admin.get("v0.1/valid/beleidskeuzes?all_filters=Afweging:beleidskeuze1011")
         assert response.status_code == 200, f"Status code was {response.status_code}"


### PR DESCRIPTION
This change will make sure that last set vigerend object will be choosen as long as the Begin_Geldigheid is not in the future.