### PR TITLE
fix: module status naming and beleidsdoel config

### DIFF
--- a/app/extensions/modules/models/models.py
+++ b/app/extensions/modules/models/models.py
@@ -141,10 +141,11 @@ class PublicModuleStatusCode(str, Enum):
 
 
 class PublicModuleObjectRevision(BaseModel):
-    Module_Object_UUID: uuid.UUID
     Module_ID: int
     Module_Title: str
-    Module_Status: str
+    Module_Status: ModuleStatusCode
+    Module_Object_UUID: uuid.UUID
+    Module_Object_Status: PublicModuleStatusCode
     Action: ModuleObjectActionFull
 
     model_config = ConfigDict(from_attributes=True)

--- a/app/extensions/modules/repository/module_object_repository.py
+++ b/app/extensions/modules/repository/module_object_repository.py
@@ -413,11 +413,13 @@ class ModuleObjectRepository(BaseRepository):
             select(
                 module_objects_filtered_subq.c.Module_ID.label("Module_ID"),
                 module_objects_filtered_subq.c.Title.label("Module_Title"),
-                module_objects_filtered_subq.c.Status.label("Module_Status"),
+                module_objects_filtered_subq.c.Status.label("Module_Object_Status"),
                 module_objects_filtered_subq.c.UUID.label("Module_Object_UUID"),
                 module_objects_filtered_subq.c.Action.label("Action"),
+                ModuleTable.Current_Status.label("Module_Status"),
             )
             .select_from(module_objects_filtered_subq)
+            .join(ModuleTable, module_objects_filtered_subq.c.Module_ID == ModuleTable.Module_ID)
             .filter(module_objects_filtered_subq.c._ObjectRowNumber == 1)
             .order_by(desc(module_objects_filtered_subq.c.Modified_Date))
         )

--- a/config/objects/beleidsdoel.yml
+++ b/config/objects/beleidsdoel.yml
@@ -176,6 +176,9 @@ models:
       description:
       start_validity:
       end_validity:
+    services:
+      computed_fields:
+        - batch_next_object_version
   beleidsdoel_extended:
     name: BeleidsdoelExtended
     fields:
@@ -224,6 +227,9 @@ models:
       end_validity:
       hierarchy_code:
     services:
+      computed_fields:
+        - next_object_version
+        - public_revisions
       insert_assets:
         fields:
           - Description


### PR DESCRIPTION
- less confusing naming for Module_status with both current and module object status.
- added beleidsdoel config