### PR TITLE
fix: AOJ title has never been send - so remove it in the state upgrader

### DIFF
--- a/app/api/domains/publications/services/state/versions/v5/state_v5_upgrader.py
+++ b/app/api/domains/publications/services/state/versions/v5/state_v5_upgrader.py
@@ -98,7 +98,7 @@ class StateV5Upgrader(StateUpgrader):
                             ],
                             domain=ow_object["bestuurlijke_grenzen_verwijzing"]["domein"],
                             valid_on=ow_object["bestuurlijke_grenzen_verwijzing"]["geldig_op"],
-                            title=ow_object["noemer"],
+                            title="",
                         )
                     )
                 case "OWRegelingsgebied":


### PR DESCRIPTION
This way the new publication will mutate the ambtsgebied with the title