### PR TITLE
fix: set db value as default

### DIFF
--- a/app/api/domains/users/endpoints/edit_user_endpoint.py
+++ b/app/api/domains/users/endpoints/edit_user_endpoint.py
@@ -61,7 +61,7 @@ def post_edit_user_endpoint(
     log_before: str = json.dumps(user_before_dict)
 
     # We handle IsActive separately as that is not really a column
-    handle_is_active: Optional[bool] = changes.pop("IsActive", None)
+    handle_is_active: Optional[bool] = changes.pop("IsActive", user.IsActive)
     if handle_is_active:
         user.Status = IS_ACTIVE
     else:


### PR DESCRIPTION
## Issue
When updating a user without modifying the `IsActive` field, the `Status` field was incorrectly left empty instead of preserving its existing value.

## Fix
Set the default value of `IsActive` to the current database value when the user is updated, ensuring the `Status` field maintains its correct value.