### PR TITLE
chore: replace python-jose for pyjwt

### DIFF
--- a/app/api/domains/users/services/security.py
+++ b/app/api/domains/users/services/security.py
@@ -3,8 +3,9 @@ import string
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, Union
 
+import jwt
 from fastapi import HTTPException, status
-from jose import JWTError, jwt
+from jwt import PyJWTError
 from passlib.context import CryptContext
 from pydantic import ValidationError
 
@@ -27,7 +28,7 @@ class Security:
         try:
             payload = jwt.decode(token, self._secret_key, algorithms=[self.ALGORITHM])
             token_data = TokenPayload(**payload)
-        except (JWTError, ValidationError):
+        except (PyJWTError, ValidationError):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Could not validate authorization token",

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ requests-toolbelt
 dependency-injector
 
 # JWT
-python-jose
+pyjwt
 passlib
 python-multipart
 bcrypt==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,8 +42,6 @@ diff-match-patch==20241021
     # via -r requirements.in
 dso @ git+https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-DSO.git@v0.8.1
     # via -r requirements.in
-ecdsa==0.19.1
-    # via python-jose
 fastapi==0.116.1
     # via -r requirements.in
 fs==2.4.16
@@ -103,10 +101,6 @@ pillow==11.3.0
     # via -r requirements.in
 platformdirs==4.3.8
     # via dso
-pyasn1==0.6.1
-    # via
-    #   python-jose
-    #   rsa
 pydantic==2.11.7
     # via
     #   -r requirements.in
@@ -116,6 +110,8 @@ pydantic==2.11.7
 pydantic-core==2.33.2
     # via pydantic
 pydantic-settings==2.10.1
+    # via -r requirements.in
+pyjwt==2.10.1
     # via -r requirements.in
 pyodbc==5.2.0
     # via -r requirements.in
@@ -131,8 +127,6 @@ python-dotenv==1.1.1
     # via
     #   pydantic-settings
     #   uvicorn
-python-jose==3.5.0
-    # via -r requirements.in
 python-multipart==0.0.20
     # via -r requirements.in
 pytz==2025.2
@@ -151,8 +145,6 @@ requests-toolbelt==1.0.0
     # via -r requirements.in
 roman==5.1
     # via dso
-rsa==4.9.1
-    # via python-jose
 shapely==2.1.1
     # via
     #   -r requirements.in
@@ -160,7 +152,6 @@ shapely==2.1.1
     #   geopandas
 six==1.17.0
     # via
-    #   ecdsa
     #   fs
     #   python-dateutil
 sniffio==1.3.1


### PR DESCRIPTION
Replaces python-jose with PyJWT to address a critical Dependabot security alert. The python-ecdsa dependency (used by python-jose) is [vulnerable](https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-API/security/dependabot/78). The upstream maintainers consider this out of scope with no planned fix.

This is a drop-in replacement with identical API behavior and no breaking changes.