### PR TITLE
fix: AB#33939 Force gebied to use area with correct title

### DIFF
--- a/app/api/domains/werkingsgebieden/services/input_geo/patch_gebiedengroep_input_geo_service.py
+++ b/app/api/domains/werkingsgebieden/services/input_geo/patch_gebiedengroep_input_geo_service.py
@@ -166,13 +166,6 @@ class PatchGebiedengroepInputGeoService:
         if existing_area:
             return existing_area.UUID
 
-        existing_area = self._area_repository.get_by_source_hash(
-            self._session,
-            onderverdeling.Geometry_Hash,
-        )
-        if existing_area:
-            return existing_area.UUID
-
         area_uuid: uuid.UUID = uuid.uuid4()
         self._area_geometry_repository.create_area(
             self._session,


### PR DESCRIPTION
This will only use Areas with the correct Onderverdeling.Title as the title will be used later as upgrade key. If such an area is not found then a new area must be created