### PR TITLE
feat: AB#32360 spaties bij wachtwoorden trimmen

### DIFF
--- a/app/api/domains/users/services/security.py
+++ b/app/api/domains/users/services/security.py
@@ -54,7 +54,16 @@ class Security:
             return False
         if hashed_password is None:
             return False
-        return self._pwd_context.verify(plain_password, hashed_password)
+        
+        passwords = dict.fromkeys(
+            [
+                plain_password,
+                plain_password.rstrip(),
+                plain_password.lstrip(),
+                plain_password.strip(),
+            ]
+        )
+        return any(self._pwd_context.verify(p, hashed_password) for p in passwords)
 
     def get_password_hash(self, password: str) -> str:
         return self._pwd_context.hash(password)

--- a/app/api/domains/users/services/security.py
+++ b/app/api/domains/users/services/security.py
@@ -54,16 +54,14 @@ class Security:
             return False
         if hashed_password is None:
             return False
-        
-        passwords = dict.fromkeys(
-            [
-                plain_password,
-                plain_password.rstrip(),
-                plain_password.lstrip(),
-                plain_password.strip(),
-            ]
-        )
-        return any(self._pwd_context.verify(p, hashed_password) for p in passwords)
+
+        variants = {
+            plain_password,
+            plain_password.strip(),
+            plain_password.lstrip(),
+            plain_password.rstrip(),
+        }
+        return any(self._pwd_context.verify(p, hashed_password) for p in variants)
 
     def get_password_hash(self, password: str) -> str:
         return self._pwd_context.hash(password)

--- a/app/api/domains/users/services/security.py
+++ b/app/api/domains/users/services/security.py
@@ -58,8 +58,6 @@ class Security:
         variants = {
             plain_password,
             plain_password.strip(),
-            plain_password.lstrip(),
-            plain_password.rstrip(),
         }
         return any(self._pwd_context.verify(p, hashed_password) for p in variants)
 


### PR DESCRIPTION
Handle passwords entered with accidental leading/trailing whitespace by verifying against stripped variants.