### PR TITLE
feat: AB#23971 - Gelockte environment laten zien bij besluiten

### DIFF
--- a/app/api/domains/publications/types/models.py
+++ b/app/api/domains/publications/types/models.py
@@ -48,6 +48,7 @@ class PublicationEnvironment(BaseModel):
     Has_State: bool
     Can_Validate: bool
     Can_Publicate: bool
+    Is_Locked: bool
     Created_Date: datetime
     Modified_Date: datetime
     model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
Boolean Is-locked meegegeven aan de return zodat de gebruiker kan zien of hij gelocked is of niet