### PR TITLE
feat: AB#33045 - Publicatievalidator rule bijlages bij besluit

### DIFF
--- a/app/api/domains/publications/publication_container.py
+++ b/app/api/domains/publications/publication_container.py
@@ -20,6 +20,7 @@ from app.api.domains.publications.services.validate_publication_service import (
     GioUniqueRule,
     AreaDesignationRefCheckRule,
     ForbiddenHtmlTagsRule,
+    AttachmentInBillReferenceRule,
 )
 
 
@@ -181,6 +182,7 @@ class PublicationContainer(containers.DeclarativeContainer):
                 ForbiddenHtmlTagsRule,
                 main_config=main_config,
             ),
+            providers.Singleton(AttachmentInBillReferenceRule),
         ),
     )
 

--- a/app/api/domains/publications/services/validate_publication_service.py
+++ b/app/api/domains/publications/services/validate_publication_service.py
@@ -469,7 +469,7 @@ class AttachmentInBillReferenceRule(ValidatePublicationRule):
             for match in matches:
                 ref_ids.add(int(match))
 
-        motivation: Optional[dict] = bill_compact.get("Motivation", [])
+        motivation: Optional[dict] = bill_compact.get("Motivation")
         if motivation:
             for appendix in motivation.get("Appendices", []):
                 matches = pattern.findall(appendix.get("Content", ""))

--- a/app/api/domains/publications/services/validate_publication_service.py
+++ b/app/api/domains/publications/services/validate_publication_service.py
@@ -421,7 +421,7 @@ class AttachmentInBillReferenceRule(ValidatePublicationRule):
     def validate(self, db: Session, request: ValidatePublicationRequest) -> List[ValidatePublicationError]:
         errors: List[ValidatePublicationError] = []
 
-        bill_compact: dict[str, Any] = request.input_data.Publication_Version.Bill_Compact or {}
+        bill_compact: Dict[str, Any] = request.input_data.Publication_Version.Bill_Compact or {}
         referenced_ids: Set[int] = self._extract_ref_ids(bill_compact)
 
         attachment_ids: Set[int] = set()

--- a/app/api/domains/publications/services/validate_publication_service.py
+++ b/app/api/domains/publications/services/validate_publication_service.py
@@ -460,23 +460,22 @@ class AttachmentInBillReferenceRule(ValidatePublicationRule):
             )
         return errors
 
+    def _extract_ref_ids(self, bill_compact: dict) -> Set[int]:
+        ref_ids: Set[int] = set()
+        pattern = re.compile(r"\[REF_BILL_PDF:(\d+)\]")
 
-def _extract_ref_ids(self, bill_compact: dict) -> Set[int]:
-    ref_ids: Set[int] = set()
-    pattern = re.compile(r"\[REF_BILL_PDF:(\d+)\]")
-
-    for appendix in bill_compact.get("appendices", []):
-        matches = pattern.findall(appendix.get("content", ""))
-        for match in matches:
-            ref_ids.add(int(match))
-
-    motivation: Optional[dict] = bill_compact.get("motivation")
-    if motivation:
-        for appendix in motivation.get("appendices", []):
-            matches = pattern.findall(appendix.get("content", ""))
+        for appendix in bill_compact.get("Appendices", []):
+            matches = pattern.findall(appendix.get("Content", ""))
             for match in matches:
                 ref_ids.add(int(match))
-    return ref_ids
+
+        motivation: Optional[dict] = bill_compact.get("Motivation", [])
+        if motivation:
+            for appendix in motivation.get("Appendices", []):
+                matches = pattern.findall(appendix.get("Content", ""))
+                for match in matches:
+                    ref_ids.add(int(match))
+        return ref_ids
 
 
 def generate_dso_gio_name(gio_title: str) -> str:

--- a/app/api/domains/publications/services/validate_publication_service.py
+++ b/app/api/domains/publications/services/validate_publication_service.py
@@ -1,7 +1,7 @@
 import re
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Dict, List, Type, Optional, Set
+from typing import Any, Dict, List, Type, Optional, Set
 
 from bs4 import BeautifulSoup, Tag, ResultSet
 from dso import GebiedsaanwijzingenFactory, Gebiedsaanwijzingen
@@ -421,7 +421,7 @@ class AttachmentInBillReferenceRule(ValidatePublicationRule):
     def validate(self, db: Session, request: ValidatePublicationRequest) -> List[ValidatePublicationError]:
         errors: List[ValidatePublicationError] = []
 
-        bill_compact: dict = request.input_data.Publication_Version.Bill_Compact or {}
+        bill_compact: dict[str, Any] = request.input_data.Publication_Version.Bill_Compact or {}
         referenced_ids: Set[int] = self._extract_ref_ids(bill_compact)
 
         attachment_ids: Set[int] = set()

--- a/app/api/domains/publications/services/validate_publication_service.py
+++ b/app/api/domains/publications/services/validate_publication_service.py
@@ -159,7 +159,7 @@ class UsedObjectInPublicationExistsRule(ValidatePublicationRule):
                             object_type=object_current.get("Object_Type"),
                             title=object_current.get("Title", ""),
                         ),
-                        messages=[f"Object {object_current.get("Code")} can't be found in publication"],
+                        messages=[f"Object {object_current.get('Code')} can't be found in publication"],
                     )
                 )
         return errors
@@ -415,6 +415,68 @@ class ForbiddenHtmlTagsRule(ValidatePublicationRule):
             if elements:
                 return tag
         return None
+
+
+class AttachmentInBillReferenceRule(ValidatePublicationRule):
+    def validate(self, db: Session, request: ValidatePublicationRequest) -> List[ValidatePublicationError]:
+        errors: List[ValidatePublicationError] = []
+
+        bill_compact: dict = request.input_data.Publication_Version.Bill_Compact or {}
+        referenced_ids: Set[int] = self._extract_ref_ids(bill_compact)
+
+        attachment_ids: Set[int] = set()
+        attachment_title_map: Dict[int, str] = {}
+
+        for attachment in request.input_data.Publication_Data.bill_attachments:
+            attachment_ids.add(attachment["id"])
+            attachment_title_map[attachment["id"]] = attachment.get("title", attachment.get("filename", ""))
+
+        unreferenced_attachments = attachment_ids - referenced_ids
+        for unreferenced_attachment_id in unreferenced_attachments:
+            errors.append(
+                ValidatePublicationError(
+                    rule="attachment_in_bill_reference_rule",
+                    object=ValidatePublicationObject(
+                        object_id=unreferenced_attachment_id,
+                        title=attachment_title_map.get(unreferenced_attachment_id, ""),
+                    ),
+                    messages=[f"Attachment with id '{unreferenced_attachment_id}' is not referenced in bill compact"],
+                )
+            )
+
+        not_found_referenced_ids = referenced_ids - attachment_ids
+
+        for not_found_id in not_found_referenced_ids:
+            errors.append(
+                ValidatePublicationError(
+                    rule="attachment_in_bill_reference_rule",
+                    object=ValidatePublicationObject(
+                        object_id=not_found_id,
+                    ),
+                    messages=[
+                        f"Attachment with id '{not_found_id}' is referenced in bill compact but not found in attachments"
+                    ],
+                )
+            )
+        return errors
+
+
+def _extract_ref_ids(self, bill_compact: dict) -> Set[int]:
+    ref_ids: Set[int] = set()
+    pattern = re.compile(r"\[REF_BILL_PDF:(\d+)\]")
+
+    for appendix in bill_compact.get("appendices", []):
+        matches = pattern.findall(appendix.get("content", ""))
+        for match in matches:
+            ref_ids.add(int(match))
+
+    motivation: Optional[dict] = bill_compact.get("motivation")
+    if motivation:
+        for appendix in motivation.get("appendices", []):
+            matches = pattern.findall(appendix.get("content", ""))
+            for match in matches:
+                ref_ids.add(int(match))
+    return ref_ids
 
 
 def generate_dso_gio_name(gio_title: str) -> str:

--- a/app/api/domains/publications/services/validate_publication_service.py
+++ b/app/api/domains/publications/services/validate_publication_service.py
@@ -431,7 +431,7 @@ class AttachmentInBillReferenceRule(ValidatePublicationRule):
             attachment_ids.add(attachment["id"])
             attachment_title_map[attachment["id"]] = attachment.get("title", attachment.get("filename", ""))
 
-        unreferenced_attachments = attachment_ids - referenced_ids
+        unreferenced_attachments: Set[int] = attachment_ids - referenced_ids
         for unreferenced_attachment_id in unreferenced_attachments:
             errors.append(
                 ValidatePublicationError(
@@ -444,7 +444,7 @@ class AttachmentInBillReferenceRule(ValidatePublicationRule):
                 )
             )
 
-        not_found_referenced_ids = referenced_ids - attachment_ids
+        not_found_referenced_ids: Set[int] = referenced_ids - attachment_ids
 
         for not_found_id in not_found_referenced_ids:
             errors.append(


### PR DESCRIPTION
In de publicatievalidator moet de volgende check worden uitgevoerd.

Bij een besluit (/publication-versions/{version_uuid}) kun je bijlages toevoegen (POST /publication-versions/{version_uuid}/attachments) en bijlages verwijderen (DELETE /publication-versions/{version_uuid}/attachments/{attachment_id}).

Zodra een bijlage is toegevoegd aan een besluit, dan ben je er nog niet. De geuploade bijlages komen dan terug in de `Attachments` bij /publication-versions/{version_uuid}. Maar deze moet ook nog benoemd worden a.d.h.v. het Attachment ID in de Bill_Compact en dan Appendices. Voorbeeld van Appendices:
```json
[
    {
        "Number": "2",
        "Title": "Bijbehorende documenten",
        "Content": "<p>[REF_BILL_PDF:26]</p><p>[REF_BILL_PDF:27]</p><p>[REF_BILL_PDF:28]</p><p>[REF_BILL_PDF:29]</p>"
    }
]
```