### PR TITLE
fix: AB#37725 Added view static endpoint for gebiedsprogramma

### DIFF
--- a/config/objects/gebiedsprogramma.yml
+++ b/config/objects/gebiedsprogramma.yml
@@ -54,6 +54,9 @@ api:
               - maatregel
     - prefix: /gebiedsprogrammas/static/{lineage_id}
       endpoints:
+        - resolver: get_object_static
+          resolver_data:
+            response_model: gebiedsprogramma_static
         - resolver: edit_object_static
           resolver_data:
             request_model: gebiedsprogramma_static_post


### PR DESCRIPTION
This was missing here: https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-API/pull/464