### PR TITLE
chore: upgrade DSO to 11.4, pip upgrade

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,9 +14,9 @@ asttokens==2.4.1
     #   stack-data
 certifi==2026.6.17
     # via requests
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-coverage[toml]==7.14.3
+coverage[toml]==7.15.0
     # via
     #   -r requirements-dev.in
     #   coverage-badge

--- a/requirements.in
+++ b/requirements.in
@@ -47,4 +47,4 @@ dicttoxml
 lxml
 
 # DSO
-git+https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-DSO.git@v0.11.3
+git+https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-DSO.git@v0.11.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ certifi==2026.6.17
     #   pyogrio
     #   pyproj
     #   requests
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via
@@ -40,7 +40,7 @@ dicttoxml==1.7.16
     # via -r requirements.in
 diff-match-patch==20241021
     # via -r requirements.in
-dso @ git+https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-DSO.git@v0.11.3
+dso @ git+https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-DSO.git@v0.11.4
     # via -r requirements.in
 fastapi==0.139.0
     # via -r requirements.in
@@ -78,7 +78,7 @@ markupsafe==3.0.3
     # via
     #   dso
     #   jinja2
-numpy==2.5.0
+numpy==2.5.1
     # via
     #   dso
     #   geopandas
@@ -192,7 +192,7 @@ typing-inspection==0.4.2
     #   pydantic-settings
 urllib3==2.7.0
     # via requests
-uvicorn[standard]==0.49.0
+uvicorn[standard]==0.51.0
     # via -r requirements.in
 uvloop==0.22.1
     # via uvicorn


### PR DESCRIPTION
Fix for DSO validation errors for OwState tekstdelen themas (no defaults for sets)

https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-API/security/dependabot/116
https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-API/security/dependabot/115
