### PR TITLE
feat: AB#3674 lege gebiedsaanwijzing

### DIFF
--- a/app/api/api_container.py
+++ b/app/api/api_container.py
@@ -228,6 +228,7 @@ class ApiContainer(containers.DeclarativeContainer):
                 module_services.ThemasCheckRule,
                 dso_thema_factory=dso_thema_factory,
             ),
+            providers.Singleton(module_services.CheckEmptyAreaDesignationTextRule, main_config=main_config),
         ),
     )
 

--- a/app/api/domains/modules/services/__init__.py
+++ b/app/api/domains/modules/services/__init__.py
@@ -3,6 +3,7 @@ from .manage_object_context_service import ManageObjectContextService
 from .object_provider import ObjectProvider
 from .validate_module_service import (
     AreaDesignationRefCheckRule,
+    CheckEmptyAreaDesignationTextRule,
     ForbidEmptyHtmlNodesRule,
     ForbiddenHtmlTagsRule,
     NewestInputGeoOnderverdelingUsedRule,

--- a/app/api/domains/modules/services/validate_module_service.py
+++ b/app/api/domains/modules/services/validate_module_service.py
@@ -468,6 +468,44 @@ class ThemasCheckRule(ValidateModuleRule):
         return errors
 
 
+class CheckEmptyAreaDesignationTextConfig(BaseModel):
+    fields: List[str]
+
+
+class CheckEmptyAreaDesignationTextRule(ValidateModuleRule):
+    def __init__(self, main_config: MainConfig):
+        self._config: CheckEmptyAreaDesignationTextRule = main_config.get_as_model(
+            "check_empty_area_designation_text",
+            CheckEmptyAreaDesignationTextConfig,
+        )
+
+    def validate(self, db: Session, request: ValidateModuleRequest) -> List[ValidateModuleError]:
+        errors: List[ValidateModuleError] = []
+
+        for object_table in request.module.object:
+            for field_name in self._config.fields:
+                value: str = str(getattr(object_table, field_name, ""))
+                soup = BeautifulSoup(value, "html.parser")
+                for gebiedsaanwijzing in soup.select('a[data-hint-type="gebiedsaanwijzing"]'):
+                    if not gebiedsaanwijzing.get_text(strip=True):
+                        errors.append(
+                            ValidateModuleError(
+                                rule="CheckEmptyAreaDesignationTextRule",
+                                object=ValidateModuleObject(
+                                    code=object_table.Code,
+                                    object_id=object_table.Object_ID,
+                                    object_type=object_table.Object_Type,
+                                    title=object_table.Title,
+                                ),
+                                severity=ValidateModuleSeverity.warning,
+                                messages=[
+                                    f"Gebiedsaanwijzing '{gebiedsaanwijzing.get('data-code', '')}' in '{field_name}' has no selected text"
+                                ],
+                            )
+                        )
+        return errors
+
+
 class ValidateModuleRunner:
     def __init__(
         self,

--- a/app/api/domains/modules/services/validate_module_service.py
+++ b/app/api/domains/modules/services/validate_module_service.py
@@ -487,7 +487,8 @@ class CheckEmptyAreaDesignationTextRule(ValidateModuleRule):
                 value: str = str(getattr(object_table, field_name, ""))
                 soup = BeautifulSoup(value, "html.parser")
                 for gebiedsaanwijzing in soup.select('a[data-hint-type="gebiedsaanwijzing"]'):
-                    if not gebiedsaanwijzing.get_text(strip=True):
+                    inner_text = gebiedsaanwijzing.get_text(strip=True)
+                    if len(inner_text) == 0:
                         errors.append(
                             ValidateModuleError(
                                 rule="check_empty_area_designation_text_rule",

--- a/app/api/domains/modules/services/validate_module_service.py
+++ b/app/api/domains/modules/services/validate_module_service.py
@@ -474,15 +474,15 @@ class CheckEmptyAreaDesignationTextConfig(BaseModel):
 
 class CheckEmptyAreaDesignationTextRule(ValidateModuleRule):
     def __init__(self, main_config: MainConfig):
-        self._config: CheckEmptyAreaDesignationTextRule = main_config.get_as_model(
-            "check_empty_area_designation_text",
+        self._config: CheckEmptyAreaDesignationTextConfig = main_config.get_as_model(
+            "check_empty_area_designation_text_rule",
             CheckEmptyAreaDesignationTextConfig,
         )
 
     def validate(self, db: Session, request: ValidateModuleRequest) -> List[ValidateModuleError]:
         errors: List[ValidateModuleError] = []
 
-        for object_table in request.module.object:
+        for object_table in request.module_objects:
             for field_name in self._config.fields:
                 value: str = str(getattr(object_table, field_name, ""))
                 soup = BeautifulSoup(value, "html.parser")
@@ -490,7 +490,7 @@ class CheckEmptyAreaDesignationTextRule(ValidateModuleRule):
                     if not gebiedsaanwijzing.get_text(strip=True):
                         errors.append(
                             ValidateModuleError(
-                                rule="CheckEmptyAreaDesignationTextRule",
+                                rule="check_empty_area_designation_text_rule",
                                 object=ValidateModuleObject(
                                     code=object_table.Code,
                                     object_id=object_table.Object_ID,

--- a/config/main.yml
+++ b/config/main.yml
@@ -55,6 +55,15 @@ publication_required_object_fields_rule:
     programma_algemeen: programma_module_validate
     beleidsdoel: beleidsdoel_module_validate
 
+check_empty_area_designation_text_rule:
+  fields:
+    - Description
+    - Cause
+    - Provincial_Interest
+    - Explanation
+    - Role
+    - Effect
+
 forbid_empty_html_nodes_rule:
   fields:
     - Description


### PR DESCRIPTION
Module validatie regel voor het checken van een lege gebiedsaanwijzing. 


`inner_text: str = aanwijzing_html.get_text(strip=True)
if len(inner_text) == 0:
    raise ValueError("Missing contents inside the gebiedsaanwijzing.")`
    
in validators.py  werkt bij het opslaan. Module validator toegevoegd voor het geval het er toch ooit een keer door heen is gekomen.

