### PR TITLE
fix: update DSO to v0.12.1, catch RenvooiConnectionError

### DIFF
--- a/app/api/domains/publications/exceptions.py
+++ b/app/api/domains/publications/exceptions.py
@@ -21,6 +21,8 @@ def dso_exception_mapper(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
+        except dso_exceptions.RenvooiConnectionError as e:
+            raise DSORenvooiException("Renvooi connection error", e.msg) from e
         except dso_exceptions.RenvooiXmlError as e:
             raise DSORenvooiException(e.msg, e.msg) from e
         except dso_exceptions.RenvooiUnauthorizedError as e:

--- a/requirements.in
+++ b/requirements.in
@@ -45,7 +45,7 @@ jinja2
 lxml
 
 # DSO
-git+https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-DSO.git@v0.12.0
+git+https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-DSO.git@v0.12.1
 
 # Azure
 azure-monitor-opentelemetry

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ dependency-injector==4.49.1
     # via -r requirements.in
 diff-match-patch==20241021
     # via -r requirements.in
-dso @ git+https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-DSO.git@v0.12.0
+dso @ git+https://github.com/Provincie-Zuid-Holland/Omgevingsbeleid-DSO.git@v0.12.1
     # via -r requirements.in
 fastapi==0.141.1
     # via -r requirements.in


### PR DESCRIPTION
Changes in DSO since last version:
- Ruff upgrade (also for tests)
- fix: [AB#39550](https://dev.azure.com/pzh-nl/65cff794-54e1-471c-9a5d-ad7538554bd4/_workitems/edit/39550) parse html only when inhoud is available
- fix: catch renvooi connection error
- fix: revert divisietekst none guard